### PR TITLE
More dev-friendly API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,8 @@ cordova plugin add http://github.com/pierrickrouxel/phonegap-icloudkv-plugin
 ```
 
 ## Using the plugin ##
-Import iCloudKV.js
 
-```HTML
-<script src="iCloudKV.js" type="text/javascript"></script>
-```
-
-The plugin creates the object `iCloudKV` with the following methods:
+The plugin becomes available when DeviceReady event is fired, it creates the object `iCloudKV` with the following methods:
 
     sync(successCallback/*(dictionary_with_all_sync_keys)*/ , failCallback) 
        In addition to calling NSUbiquitousKeyValueStore sync method the plugin's sync returns the dictionary holding all iCloud data for the app.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ iOS iCloud KeyValue Store plugin for PhoneGap
 
 Allows storing small amounts of configuration data in iCloud from Cordova/PhoneGap. Wraps NSUbiquitousKeyValueStore class.
 
+This plugin is forked from http://github.com/pierrickrouxel/phonegap-icloudkv-plugin
+
 ## Compatibility
 
 Cordova/PhoneGap >= 3.0
@@ -12,7 +14,7 @@ Cordova/PhoneGap >= 3.0
 ## Adding the plugin to your project ##
 
 ```
-cordova plugin add http://github.com/pierrickrouxel/phonegap-icloudkv-plugin
+cordova plugin add https://github.com/alexportnoy/phonegap-icloudkv-plugin
 ```
 
 ## Using the plugin ##
@@ -40,11 +42,16 @@ For the simplest (but probably sufficient for most apps) implementation you will
 
 ## Thanks
 
-Special thanks to Alex Drel who create the plugin for PhoneGap 2.
+Special thanks to Alex Drel and Pierrick Rouxel, this plugin is based on their work.
 
 ## Bugs and contributions
 
 If you have a patch, fork my repo and send me a pull request. Submit bug reports on GitHub, please.
 
+## Changelog
 
+v0.3.0:
+First version of forked plugin:
+- Added proper wrapper code for including plugin into application using clobbers
+- Added plugin meta-data for cordova registry
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "phonegap-icloudkv-plugin",
+  "version": "0.3.0",
+  "description": "Cordova iCloud Key Value Plugin",
+  "cordova": {
+    "id": "com.portnou.cordova.plugin.iCloudKV",
+    "platforms": [
+      "ios"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alexportnoy/phonegap-icloudkv-plugin.git"
+  },
+  "keywords": [
+    "cordova",
+    "icloud",
+    "ios",
+    "ecosystem:cordova",
+    "cordova-ios"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.0.0"
+    }
+  ],
+  "author": "Alexander Portnoy",
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/alexportnoy/phonegap-icloudkv-plugin/issues"
+  },
+  "homepage": "https://github.com/alexportnoy/phonegap-icloudkv-plugin"
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,14 +2,20 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="fr.pierrickrouxel.iCloudKV"
-      version="0.1.0">
+      version="0.2.0">
 
     <name>iCloudKV</name>
     <description>Cordova iCloud Key Value Plugin</description>
     <license>Apache 2.0</license>
-    <keywords>cordova,icloud</keywords>
-
-    <asset src="www/iCloudKV.js" target="iCloudKV.js" />
+    <keywords>cordova,icloud,ios</keywords>
+    
+    <engines>
+        <engine name="cordova" version=">=3.0.0" />
+    </engines>
+    
+    <js-module src="www/iCloudKV.js" name="iCloudKV">
+        <clobbers target="iCloudKV" />
+    </js-module>
 
     <!-- ios -->
     <platform name="ios">    

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-           id="fr.pierrickrouxel.iCloudKV"
-      version="0.2.0">
+           id="com.portnou.cordova.plugin.iCloudKV"
+      version="0.3.0">
 
     <name>iCloudKV</name>
     <description>Cordova iCloud Key Value Plugin</description>
+    <author>Alexander S Portnoy</author>
     <license>Apache 2.0</license>
     <keywords>cordova,icloud,ios</keywords>
+    <repo>https://github.com/alexportnoy/phonegap-icloudkv-plugin</repo>
     
     <engines>
         <engine name="cordova" version=">=3.0.0" />
@@ -25,7 +27,7 @@
             </feature>
         </config-file>
         <header-file src="src/ios/iCloudKV.h" />
-        <source-file src="src/ios/iCloudKV.m" />          
+        <source-file src="src/ios/iCloudKV.m" />
     </platform>
 
 </plugin>

--- a/src/ios/iCloudKV.m
+++ b/src/ios/iCloudKV.m
@@ -110,7 +110,7 @@
             NSLog(@"iCloudKV server change notification.");
             NSDictionary    *changedKeys   = [[receivedNotification userInfo] valueForKey:NSUbiquitousKeyValueStoreChangedKeysKey];
 
-            NSString *jsStatement = [NSString stringWithFormat:@"iCloudKV.onChange(%@);", [NSJSONSerialization dataWithJSONObject:changedKeys options:NSJSONWritingPrettyPrinted error:nil]];
+            NSString *jsStatement = [NSString stringWithFormat:@"iCloudKV.didChanged(%@);", [NSJSONSerialization dataWithJSONObject:changedKeys options:NSJSONWritingPrettyPrinted error:nil]];
             [self writeJavascript:jsStatement];
             break;
     }

--- a/www/iCloudKV.js
+++ b/www/iCloudKV.js
@@ -1,34 +1,36 @@
 // Copyright (c) Alex Drel 2012
 
-var iCloudKV = (function (ckv) {
 
-    var onChange = null;
+	var iCloudKV = exports;
 
-    ckv.sync = function (success, fail) {
-        return cordova.exec(success /*(dictionary_with_all_sync_keys)*/, fail, "iCloudKV", "sync", []);
+	var exec = require('cordova/exec');
+	var cordova = require('cordova');
+    
+    iCloudKV.onChange = null;
+    
+    iCloudKV.sync = function(success, fail) {
+        exec(success /*(dictionary_with_all_sync_keys)*/, fail, "iCloudKV", "sync", []);
     };
-
-    ckv.save = function (key, value, success) {
-        return cordova.exec(success, null, "iCloudKV", "save", [key, value]);
+    
+    iCloudKV.save = function (key, value, success) {
+        exec(success, null, "iCloudKV", "save", [key, value]);
     };
-
-    ckv.load = function (key, success, fail) {
-        return cordova.exec(success /*(value)*/, fail, "iCloudKV", "load", [key]);
+    
+    iCloudKV.load = function (key, success, fail) {
+        exec(success /*(value)*/, fail, "iCloudKV", "load", [key]);
     };
-
-    ckv.remove = function (key, success) {
-        return cordova.exec(success, null, "iCloudKV", "remove", [key]);
+    
+    iCloudKV.remove = function (key, success) {
+        exec(success, null, "iCloudKV", "remove", [key]);
     };
-
-    ckv.monitor = function (notification /*(keys)*/, success) {
-        onChange = notification;
-        return cordova.exec(success, null, "iCloudKV", "monitor", []);
+    
+    iCloudKV.monitor = function (notification /*(keys)*/, success) {
+        this.onChange = notification;
+        exec(success, null, "iCloudKV", "monitor", []);
     };
-
-    ckv.onChange = function (keys) {
-        if (onChange)
-            onChange(keys);
+    
+    iCloudKV.didChanged = function (keys) {
+        if (this.onChange)
+            this.onChange(keys);
     };
-
-    return ckv;
-})(iCloudKV || {});
+    


### PR DESCRIPTION
Hi,

I've slightly changed the plugin's JS API. In particular - removed the need to manually include iCloudKV.js, plugin is now available via clobbers after DeviceReady event is fired.

Please, take a look if you're interested.