### PR TITLE
adding writeJavascript as interface

### DIFF
--- a/src/ios/iCloudKV.h
+++ b/src/ios/iCloudKV.h
@@ -13,4 +13,6 @@
 - (void)load:(CDVInvokedUrlCommand *)command;
 - (void)remove:(CDVInvokedUrlCommand *)command;
 - (void)monitor:(CDVInvokedUrlCommand *)command;
+- (void)writeJavascript:(CDVInvokedUrlCommand *)command;
+
 @end


### PR DESCRIPTION
Resolves the issue: "no visible @interface for 'iCloudKV' declares the selector 'writeJavascript:'"